### PR TITLE
schema: Ensure the pattern matches the known CVE sequence lengths

### DIFF
--- a/src/schema/vulnerability.schema.json
+++ b/src/schema/vulnerability.schema.json
@@ -9,7 +9,7 @@
       "recommendation": { "type": "string" },
       "cve": {
         "type": "string",
-        "pattern": "/^CVE-[0-9]{4}-[0-9]{5}$/i"
+        "pattern": "/^CVE-[0-9]{4}-[0-9]{4,}$/i"
       },
       "advisory": {
         "type": "string",


### PR DESCRIPTION
I don't see any guidelines how these patches should be done, but PR so I dont forget about it :smile: 

---

The current schema only matches 5 digits in the sequence length, however
MITRE defines this to be "four or more digits"[1]. The longest I have
observed is 7 digits[2], which is also an example on the website. This
patch ensures we cover this range of known CVE IDs.

[1]: https://cve.mitre.org/about/faqs.html#what_is_cve_entry
[2]: https://nvd.nist.gov/vuln/detail/CVE-2018-1000035

Signed-off-by: Morten Linderud <morten@linderud.pw>