### PR TITLE
Add Eduardo Barretto (Ubuntu/Canonical) to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,5 +52,6 @@ Meeting agenda is published prior to the meeting in a GitHub issue with the labe
 - [Morten Linderud (Arch Linux)](https://github.com/Foxboron)
 - [Josh Bressers (Elastic)](https://github.com/joshbressers/)
 - [Gilles Gravier (Wipro)](https://github.com/gravax)
+- [Eduardo Barretto (Ubuntu/Canonical)](https://github.com/dodys)
 
 We use the [vulnerability-disclosures-wg](https://github.com/orgs/ossf/teams/vulnerability-disclosures-wg) GitHub team.


### PR DESCRIPTION
Signed-off-by: Eduardo Barretto <eduardo.barretto@canonical.com>