### PR TITLE
Add agenda link

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The working group meets every two weeks, on Monday at 4:00 PM GMT / 8:00 AM PT. 
 
 Contact [Marcin](mailto:marcin.hoppe@auth0.com) if you wish to be added to the invite list.
 
-Meeting agenda is published prior to the meeting in a GitHub issue with the label `meeting`. The issue contains agenda items and logistics details like date, time, Zoom link and a link to meeting notes document.
+Meeting [agenda](https://github.com/ossf/wg-vulnerability-disclosures/issues?q=is%3Aissue+is%3Aopen+label%3Ameeting) is published prior to the meeting in a GitHub issue with the label `meeting`. The issue contains agenda items and logistics details like date, time, Zoom link and a link to meeting notes document.
 
 ### **Meeting Notes**
 


### PR DESCRIPTION
Make it easier to find agendas using link to issue query with label
'meeting'

Signed-off-by: Dan Middleton <dan.middleton@intel.com>