### PR TITLE
Edits to mission, adds "active" to Maintainer role

### DIFF
--- a/CHARTER.md
+++ b/CHARTER.md
@@ -8,7 +8,7 @@ This Technical Charter sets forth the responsibilities and procedures for techni
 
 #### 1. Mission and Scope of the Technical Initiative
 
-- a. The mission of the Technical Initiative is to promote sound coordinated vulnerability disclosure practices, tools, and learnings to the open source ecosystem.
+- a. The mission of the Technical Initiative is to promote sound vulnerability disclosure practices within the OpenSSF and wider open source ecosystem, and develop tools and resources that address gaps in vulnerability disclosure for open source.
 
 - b. The scope of the Technical Initiative includes collaborative development under the Technical Initiative License (as defined herein) supporting the mission, including organizing collaboration activities, defining best practices, documentation, testing, integration, and the creation of other artifacts that support the mission.
 
@@ -26,7 +26,7 @@ This Technical Charter sets forth the responsibilities and procedures for techni
 
    - iii. A Contributor may become a Collaborator by a majority approval of the existing Collaborators. A Collaborator may be removed by a majority approval of the other existing Collaborators.
 
-   - iv. Maintainers are the initial Collaborators defined at the creation of the Technical Initiative. The Maintainers will determine the process for selecting future Maintainers. A Maintainer may be removed by two-thirds approval of the other existing Maintainers, or a majority of the other existing Collaborators.
+   - iv. Maintainers are the initial Collaborators defined at the creation of the Technical Initiative. The Maintainers will determine the process for selecting future Maintainers. A Maintainer may be removed by two-thirds approval of the other existing Maintainers, or a majority of the other existing Collaborators. Maintainers are expected to be active participants in the Technical Intiative to retain their Maintainer status.
 
 - d. Participation in the Technical Initiative through becoming a Contributor, Collaborator, or Maintainer is open to anyone, whether a OpenSSF member or not, so long as they abide by the terms of this Technical Charter. 
 


### PR DESCRIPTION
Line 11: Suggested edits to the Mission to 1) broaden the advocacy/tools to general vuln disclosure and 2) set the tone around tooling focus (ie "solve gaps"). 

Line 29: Adds the idea that Maintainers are expected to be "active" in the WG to retain their Maintainer status. Active is intentionally undefined and -- in the ethos of "minimum viable governance" -- could be defined by the TSC if this becomes an issue. 

Signed-off-by: Anne Bertucio <annebertucio@google.com>