### PR TITLE
Create security_advisory.md

### DIFF
--- a/templates/security_advisory.md
+++ b/templates/security_advisory.md
@@ -1,0 +1,34 @@
+# Summary
+
+Usually about a paragraph in length, we expect an easy to digest summary of the vulnerability here. Something we can explain to our peers or use to motivate a patching request or update.
+
+## Severity & Impact
+
+Use your judgement to determine how severe the vulnerability is here. A discussion about its impact and potential role in an attack can also be used to motivate your assessment here. No need to be dramatic; be factual, everyone will thank you for it.
+
+# Proof of Concept
+
+This here is your `PoC.$ext`, and its various artifacts needed to reproduce the vulnerability:
+```
+#include funcode
+```
+
+# Analysis
+
+Take your time here, this will be the meat of your report.
+
+## Background
+
+Any information useful to understand the vulnerability. Context will help for non-initiated.
+
+## Vulnerability Details
+
+Adjust these titles as you see fit, but a detailed explanation as to why this is a vulnerability, and where it is, and how to exploit it is commendable.
+
+## Mitigation / Patching
+
+Assuming we can fix this, or at least mitigate the issue, it would be nice to mention it here. A short discussion and inclusion of the product owners's patching activity can be discussed here as well.
+
+# Timeline and Credits
+
+When was this discovered? reported? patched under embargo? rolled out publicly? You may also include potential pings and repeated communications here as well; it is important information for the community to know what kind of response a project/product owner provides when informed of vulnerabilities.


### PR DESCRIPTION
Adding a security advisory template for GH security advisories.

As discussed in https://github.com/ossf/wg-vulnerability-disclosures/issues/110 and the team meeting.