### PR TITLE
Create vulnerability_report.md

### DIFF
--- a/templates/vulnerability_report.md
+++ b/templates/vulnerability_report.md
@@ -1,0 +1,25 @@
+# Summary
+
+Usually about a paragraph in length, we expect an easy to digest summary of the vulnerability here. Something we can explain to our peers or use to motivate a patching request or update.
+
+## Severity & Impact
+
+Use your judgement to determine how severe the vulnerability is here. A discussion about its impact and potential role in an attack can also be used to motivate your assessment here. No need to be dramatic; be factual, everyone will thank you for it.
+
+# Proof of Concept
+
+This here is your `PoC.$ext`, and its various artifacts needed to reproduce the vulnerability:
+```
+#include funcode
+```
+
+# Analysis
+
+Take your time here, this will be the meat of your report.
+
+# Disclosure Timeline Information
+
+Be precise about your disclosure timeline here. If you include your timeline in the initial report, it stays clear about what kinds of delays you are able to offer, and helps the product / project owners plan their response accordingly as well. Recommended blob:
+```
+This vulnerability, the proof of concept and its analysis will be made public 90 days from now. If the issue is not fixed in time, the proof of concept code and detailed analysis will be further delayed by 30 days.
+```

--- a/templates/vulnerability_report.md
+++ b/templates/vulnerability_report.md
@@ -17,6 +17,10 @@ This here is your `PoC.$ext`, and its various artifacts needed to reproduce the 
 
 Take your time here, this will be the meat of your report.
 
+# Suggested Fixes
+
+If you have an idea about how to fix this, please help the maintainers with a suggestion here.
+
 # Disclosure Timeline Information
 
 Be precise about your disclosure timeline here. If you include your timeline in the initial report, it stays clear about what kinds of delays you are able to offer, and helps the product / project owners plan their response accordingly as well. Recommended blob:


### PR DESCRIPTION
Adding a template for researchers' as well.

This could potentially also be provided on the security policy for GH projects so as to standardize a little bit of the reporting.

Issue: https://github.com/ossf/wg-vulnerability-disclosures/issues/110