### PR TITLE
Add information about Red Hat as a Root

### DIFF
--- a/docs/guides/becoming-a-cna-as-an-open-source-org-or-project.md
+++ b/docs/guides/becoming-a-cna-as-an-open-source-org-or-project.md
@@ -2,7 +2,6 @@
 
 > **NOTE:**
 > This document was drafted using the following document revisions:
-> 
 > * CVE Numbering Authority (CNA) Rules, Version 3.0
 > * CVE Record Dispute Policy, Version 1.0
 > * CVE Program Policy and Procedure for End of Life Products, Version 1.2
@@ -30,7 +29,7 @@ CVE Numbering Authorities (CNAs) are the entities that can allocate CVE IDs and 
 
 Below are some of the benefits of becoming a CNA:
 
-* **Provide high-quality authoritative CVE Records for your users.** CVE Records created by third-parties can be incomplete or inaccurate. 
+* **Provide high-quality authoritative CVE Records for your users.** CVE Records created by third-parties can be incomplete or inaccurate.
 * **CVEs can't be issued for projects in a CNA's scope without first reporting to the CNA.** This means that reporters _must_ initially engage with your CNA, thus reducing confusion and allowing subject-matter experts on the project and security policy to weigh in on whether to create a CVE for a given disclosure.
 * **Assign CVE IDs without needing to share embargoed information with other organizations.** This allows the project to determine for themselves  who, if anyone, needs or gets pre-disclosure information.
 
@@ -60,19 +59,19 @@ Preferably 2 or more and ordered primary, secondary, etc. For each point of cont
 ### Time and reporting obligations
 
 * **During CNA onboarding:**
-    * List of 3 available dates and times for a 1-hour call with CNA Program with all Points of Contact to answer questions and exercises. These three dates must be at least 3 weeks in the future.
-    * Complete practice exercises after the initial onboarding call and submit your exercises to the CNA Program for approval.
+  * List of 3 available dates and times for a 1-hour call with CNA Program with all Points of Contact to answer questions and exercises. These three dates must be at least 3 weeks in the future.
+  * Complete practice exercises after the initial onboarding call and submit your exercises to the CNA Program for approval.
 
 * **Throughout CNA operations:**
-    * **No time requirements on timeline for [non-public aspects of coordinated vulnerability disclosure](https://www.cve.org/ResourcesSupport/AllResources/CNARules#appendix_d_disclosure_and_embargo_policies) (ie reporting, acknowledging, disclosures, etc).**
-    * CVE dispute requests have timeliness requirements:
-        * 3 days to acknowledge the dispute.
-        * 5 days after acknowledgement to make a decision or extend and inform the requester.
-        * 15 days after optional extension to make a final decision or escalate up to your Root, resulting in a new dispute cycle.
-    * Get approval from Root with changes to CNA record data like POCs, scope, vulnerability disclosure policy and location, etc.
-    * CNA inactivity policy: 6 months of no CVE IDs allocated will cause a few heartbeat emails sent to POCs. After three attempts to contact your organization will be removed from the CNA Program (and you can reapply to join again).
-    * Yearly review of CNA Rules and checking CNA mailing list (sent to POC email addresses).
-    * Recommended yearly rotation of CVE Services credentials.
+  * **No time requirements on timeline for [non-public aspects of coordinated vulnerability disclosure](https://www.cve.org/ResourcesSupport/AllResources/CNARules#appendix_d_disclosure_and_embargo_policies) (ie reporting, acknowledging, disclosures, etc).**
+  * CVE dispute requests have timeliness requirements:
+    * 3 days to acknowledge the dispute.
+    * 5 days after acknowledgement to make a decision or extend and inform the requester.
+    * 15 days after optional extension to make a final decision or escalate up to your Root, resulting in a new dispute cycle.
+  * Get approval from Root with changes to CNA record data like POCs, scope, vulnerability disclosure policy and location, etc.
+  * CNA inactivity policy: 6 months of no CVE IDs allocated will cause a few heartbeat emails sent to POCs. After three attempts to contact your organization will be removed from the CNA Program (and you can reapply to join again).
+  * Yearly review of CNA Rules and checking CNA mailing list (sent to POC email addresses).
+  * Recommended yearly rotation of CVE Services credentials.
 
 ### Organization information
 
@@ -156,7 +155,6 @@ There are optional videos available with a historical overview of CVE Services a
 * [Introduction to CVE Services](https://www.youtube.com/watch?v=K2OoRpDhzss) (37 minutes)
 * [CVE JSON 5 Format](https://www.youtube.com/watch?v=YWZECqzRI7M) (45 minutes)
 
-
 ### CNA Rules
 
 There is a [list of rules for all CNAs](https://www.cve.org/ResourcesSupport/AllResources/CNARules) published by CVE. Many of these rules apply to CNAs which aren't sub-CNAs like the PSF. The rules that do apply to Sub-CNAs are documented in these sections, read each of these:
@@ -179,35 +177,35 @@ Upon being accepted into the CNA Program there is also a CNA-only Slack channel 
 
 ## Q&A
 
-**Q: Do I need to be an organization / company to become a CNA?**
+### Q: Do I need to be an organization / company to become a CNA?
 
 A: No. Individual people could theoretically be a CNA, most of what matters is that you follow the rules of the program consistently and you’re able to meet the time requirements for CVE disputes.
 
-**Q: Does everyone who’s handling CNA operations need to be a part of the same organization / company that the CNA represents?**
+### Q: Does everyone who’s handling CNA operations need to be a part of the same organization / company that the CNA represents?
 
 A: No. You can create CVE Services accounts for people outside your organization, including volunteers. What matters is that they know and follow CNA Rules when operating the CNA and that credentials are handled securely.
 
-**Q: Should I scope end-of-life products / releases?**
+### Q: Should I scope end-of-life products / releases?
 
 A: End-of-life products / releases can still have CVEs assigned, whether you have them scoped or not is up to you and only changes whether MITRE (CNA-LR) or your CNA is issuing the CVEs. Advice is to start with end-of-life products / releases scoped and drop them from scope if the workload is too much.
 
-**Q: Do I have to provide a CVSS score?**
+### Q: Do I have to provide a CVSS score?
 
 A: No, that field is optional. NVD (National Vulnerability Database) tries to provide a CVSS score on every CVE.
 
-**Q: Can all my CVE ID blocks be managed through CVE Services rather than through another service?**
+### Q: Can all my CVE ID blocks be managed through CVE Services rather than through another service?
 
 A: Yes, and this is the recommended way. However, CVE Services cannot be used as a database for unpublished or incomplete records, submitting a CVE Record to CVE Services immediately moves it to the published state. Coordination on CVE Records thus cannot happen via CVE Services alone.
 
-**Q: By becoming a CNA can I update CVEs that were issued against our newly scoped projects?**
+### Q: By becoming a CNA can I update CVEs that were issued against our newly scoped projects?
 
 A: No, you need to use the CVE Record update / dispute process with the assigner of each pre-existing CVE.
 
-**Q: What does “web-scraping” advisory location mean? (From an onboarding form)**
+### Q: What does “web-scraping” advisory location mean? (From an onboarding form)
 
 A: This is a location where all CVE IDs appear in text such that they can be scraped by a web scraping process. This web scraping process is sometimes used by CVE to ensure that CVE IDs that get published as advisories are made publicly available in a timely manner. For monitored locations, CVE will give you a reminder if you publish an advisory and don’t publish the corresponding CVE Record in a few days. Publishing a CVE ID (like in an advisory) without publishing the corresponding CVE Record is called “[Reserved but public (RBP)](https://www.cve.org/ResourcesSupport/Glossary#glossaryRBP)” and is not  permitted by the CNA Rules.
 
-**Q: Is CNA status permanent? What are the ways CNA status can be revoked?**
+### Q: Is CNA status permanent? What are the ways CNA status can be revoked?
 
 A: CNA status is not permanent, it can be relinquished voluntarily any time by writing to the CNA’s Root. CNA status can be revoked if …
 

--- a/docs/guides/becoming-a-cna-as-an-open-source-org-or-project.md
+++ b/docs/guides/becoming-a-cna-as-an-open-source-org-or-project.md
@@ -102,9 +102,13 @@ Optionally have the answers to this information:
 ### Contact Red Hat to become a CNA under their Root
 
 [Red Hat is the recommended Root for Open Source projects](https://www.cve.org/PartnerInformation/ListofPartners/partner/redhat). You can contact them to start the conversation at `RootCNA-Coordination@redhat.com`.
+
 If you don't want Red Hat to be your Root you can contact any other Root (search "Root" in the [list of CNAs](https://www.cve.org/PartnerInformation/ListofPartners)).
 
-You can always ask your prospective Root questions about the process of becoming and operating a CNA, they will be an excellent resource to you.
+> [!TIP]
+> A [Root CNA](https://www.cve.org/ResourcesSupport/Glossary#glossaryRoot) is an organization authorized within the CVE Program that is responsible, within a specific Scope, for the recruitment, training, and governance of one or more entities that are a CNA, CNA-LR, or another Root. Red Hat became a Root CNA to develop governance focusing on **open source software (OSS)** needs. Red Hat uses this approach to invite the community to create unique and different aspects of OSS for the CVE Program to consider. For example, as a Root CNA, Red Hat has created opportunities for CNAs to collaborate with other projects and communities, has championed OSS automated tooling improvements within the Program, and has successfully helped OSS projects like [curl](https://curl.se/docs/CVE-2023-52071.html) navigate CVE complexities. Learn more [here](https://access.redhat.com/articles/red_hat_cve_program) & [here](https://github.com/ossf/wg-vulnerability-disclosures/issues/157#issuecomment-2545939617) about Red Hat's engagement with CVE.
+
+You can always ask your prospective Root questions about the process of becoming and operating a CNA - they will be an excellent resource to you.
 
 ### Submitting the Onboarding Form
 

--- a/docs/guides/becoming-a-cna-as-an-open-source-org-or-project.md
+++ b/docs/guides/becoming-a-cna-as-an-open-source-org-or-project.md
@@ -2,6 +2,7 @@
 
 > **NOTE:**
 > This document was drafted using the following document revisions:
+> 
 > * CVE Numbering Authority (CNA) Rules, Version 3.0
 > * CVE Record Dispute Policy, Version 1.0
 > * CVE Program Policy and Procedure for End of Life Products, Version 1.2


### PR DESCRIPTION
This pull request includes an update to the `docs/guides/becoming-a-cna-as-an-open-source-org-or-project.md` file to provide additional information about Root CNAs and their role in the CVE Program. The most important changes include adding a detailed explanation about Root CNAs, specifically Red Hat's role and contributions, and enhancing the readability of the document with a tip format.

Closes https://github.com/ossf/wg-vulnerability-disclosures/issues/157.